### PR TITLE
fix(BPC-7578):  nil accessor_keys

### DIFF
--- a/lib/simple_hstore_accessor.rb
+++ b/lib/simple_hstore_accessor.rb
@@ -21,11 +21,7 @@ module SimpleHstoreAccessor
       serialize hstore_attribute, ActiveRecord::Coders::Hstore
     end
 
-    class << self
-      attr_reader :accessor_keys
-    end
-
-    @accessor_keys = Array(keys).flatten.map(&:to_sym)
+    accessor_keys = Array(keys).flatten.map(&:to_sym)
 
     accessor_keys.each do |key|
       define_method("#{key}=") do |value|
@@ -40,7 +36,7 @@ module SimpleHstoreAccessor
     end
 
     define_method :write_attribute do |attr_name, value|
-      if self.class.accessor_keys.include?(attr_name.to_sym)
+      if accessor_keys.include?(attr_name.to_sym)
         public_send("#{attr_name}=", value)
       else
         super(attr_name, value)
@@ -48,7 +44,7 @@ module SimpleHstoreAccessor
     end
 
     define_method :read_attribute do |attr_name|
-      if self.class.accessor_keys.include?(attr_name.to_sym)
+      if accessor_keys.include?(attr_name.to_sym)
         public_send(attr_name)
       else
         super(attr_name)

--- a/spec/app/models/dummy_subclass_spec.rb
+++ b/spec/app/models/dummy_subclass_spec.rb
@@ -1,0 +1,49 @@
+# coding: utf-8
+require 'spec_helper'
+
+describe Dummies::DummySubclass do
+  let(:dummy) { described_class.new(latitude: 7, longitude: 11) }
+
+  it { expect(dummy).to respond_to(:properties) }
+
+  it { expect(dummy).to respond_to(:latitude) }
+  it { expect(dummy).to respond_to(:latitude=) }
+  it { expect(dummy).to respond_to(:latitude_will_change!) }
+  it { expect(dummy).to respond_to(:latitude_changed?) }
+
+  it { expect(dummy).to respond_to(:longitude) }
+  it { expect(dummy).to respond_to(:longitude=) }
+  it { expect(dummy).to respond_to(:longitude_will_change!) }
+  it { expect(dummy).to respond_to(:longitude_changed?) }
+
+  it { expect(dummy).to respond_to(:write_attribute) }
+  it { expect(dummy).to respond_to(:read_attribute) }
+
+  describe '#latitude=' do
+    it { expect { dummy.latitude = 14 }.to change { dummy.latitude }.from(7).to(14) }
+  end
+
+  describe '#write_attribute' do
+    context 'when called with hstore attribute' do
+      before { dummy.write_attribute(:longitude, 5) }
+
+      it { expect(dummy.longitude).to eq(5) }
+    end
+
+    context 'when called with regular attribute' do
+      before { dummy.write_attribute(:regular_attribute, 'changed') }
+
+      it { expect(dummy.regular_attribute).to eq('changed') }
+    end
+  end
+
+  describe '#read_attribute' do
+    context 'when called with hstore attribute' do
+      it { expect(dummy.read_attribute(:longitude)).to eq(dummy.longitude) }
+    end
+
+    context 'when called with regular attribute' do
+      it { expect(dummy.read_attribute(:regular_attribute)).to eq(dummy.regular_attribute) }
+    end
+  end
+end

--- a/spec/internal/app/models/dummies/dummy_subclass.rb
+++ b/spec/internal/app/models/dummies/dummy_subclass.rb
@@ -1,0 +1,5 @@
+# coding: utf-8
+module Dummies
+  class DummySubclass < Dummy
+  end
+end


### PR DESCRIPTION
проблема:
в self.class.accessor_keys может быть nil, если store_accessor определен не у самого класса, а у его суперкласса
